### PR TITLE
docs: fix broken url for aks image cleaner

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -119,7 +119,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `image_cleaner_interval_hours` - (Optional) Specifies the interval in hours when images should be cleaned up.
 
--> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableImageCleanerPreview` is enabled and the Resource Provider is re-registered, see [the documentation]([Microsoft.ContainerService/EnableImageCleanerPreview](https://learn.microsoft.com/en-us/azure/aks/image-cleaner) for more information.
+-> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableImageCleanerPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://learn.microsoft.com/en-us/azure/aks/image-cleaner) for more information.
 
 * `ingress_application_gateway` - (Optional) A `ingress_application_gateway` block as defined below.
 


### PR DESCRIPTION
This PR will fix a broken url to the image cleaner preview feature documentation